### PR TITLE
Use version 1.0 of NLLGrid (June 2018)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,4 @@ include backtrackbb/RELEASE-VERSION
 include backtrackbb/lib/__init__.py
 include backtrackbb/c_libs/map_project/*.h
 include backtrackbb/c_libs/rosenberger/*.h
+include backtrackbb/nllgrid/RELEASE-VERSION

--- a/backtrackbb/mod_btbb.py
+++ b/backtrackbb/mod_btbb.py
@@ -13,7 +13,7 @@ from .bp_types import Trigger
 from .map_project import rect2latlon
 from .grid_projection import sta_GRD_Proj
 from .plot import bp_plot
-from .NLLGrid import NLLGrid
+from .nllgrid import NLLGrid
 from .summary_cf import summary_cf
 
 

--- a/backtrackbb/nllgrid/NLLGrid.py
+++ b/backtrackbb/nllgrid/NLLGrid.py
@@ -74,7 +74,7 @@ class TakeOffAngles(Union):
                 ('ival', c_ushort*2)]
 
 
-class NLLGrid():
+class NLLGrid(object):
     """Class for manipulating NLL grid files.
 
     It has methods to read and write grid files,

--- a/backtrackbb/nllgrid/NLLGrid.py
+++ b/backtrackbb/nllgrid/NLLGrid.py
@@ -1,32 +1,92 @@
 # -*- coding: utf8 -*-
-# NLLGrid.py
-#
-# Reading and writing of NLL grid files
-#
-# (c) 2013-2015 - Natalia Poiata <poiata@ipgp.fr>,
-#                 Claudio Satriano <satriano@ipgp.fr>
+"""
+Reading and writing of NonLinLoc grid files.
+
+:copyright:
+    2013-2018 Claudio Satriano <satriano@ipgp.fr>,
+              Natalia Poiata <poiata@ipgp.fr>
+:license:
+    CeCILL Free Software License Agreement, Version 2.1
+    (http://www.cecill.info/index.en.html)
+"""
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import math
 import numpy as np
 from scipy.ndimage import zoom
-from array import array
+from ctypes import Union, c_float, c_ushort
 from copy import deepcopy
+from pyproj import Proj
+from collections import Iterable
+
+
+valid_grid_types = (
+    'VELOCITY',
+    'VELOCITY_METERS',
+    'SLOWNESS',
+    'VEL2',
+    'SLOW2',
+    'SLOW2_METERS',
+    'SLOW_LEN',
+    'STACK',
+    'TIME',
+    'TIME2D',
+    'PROB_DENSITY',
+    'MISFIT',
+    'ANGLE',
+    'ANGLE2D'
+)
+
+valid_float_types = {
+    # NLL_type: numpy_type
+    'FLOAT': 'float32',
+    'DOUBLE': 'float64'
+}
+
+valid_projections = (
+    'NONE',
+    'SIMPLE',
+    'LAMBERT'
+)
+
+valid_ellipsoids = (
+    'WGS-84',
+    'GRS-80',
+    'WGS-72',
+    'Australian',
+    'Krasovsky',
+    'International',
+    'Hayford-1909',
+    'Clarke-1880',
+    'Clarke-1866',
+    'Airy',
+    'Bessel',
+    'Hayford-1830',
+    'Sphere'
+)
+
+
+class TakeOffAngles(Union):
+    """Union-style class for decoding take off angles."""
+
+    _fields_ = [('fval', c_float),
+                ('ival', c_ushort*2)]
 
 
 class NLLGrid():
-    """
-    Class for manipulating NLL grid files.
+    """Class for manipulating NLL grid files.
+
     It has methods to read and write grid files,
     compute statistics and plot.
     """
 
     def __init__(self,
                  basename=None,
-                 nx=0, ny=0, nz=0,
+                 nx=1, ny=1, nz=1,
                  x_orig=0., y_orig=0., z_orig=0.,
-                 dx=0., dy=0., dz=0.):
+                 dx=1., dy=1., dz=1.):
+        """Init a NLLGrid object."""
         self.nx = nx
         self.ny = ny
         self.nz = nz
@@ -36,19 +96,20 @@ class NLLGrid():
         self.dx = dx
         self.dy = dy
         self.dz = dz
-        self.type = None
-        self.proj_name = None
-        self.proj_ellipsoid = None
+        self.__type = None
+        self.__proj_name = None
+        self.__proj_ellipsoid = None
         self.orig_lat = float(0)
         self.orig_lon = float(0)
-        self.first_std_paral = None
-        self.second_std_paral = None
+        self.first_std_paral = 0
+        self.second_std_paral = 0
         self.map_rot = float(0)
         self.station = None
         self.sta_x = float(0)
         self.sta_y = float(0)
         self.sta_z = float(0)
-        self.array = None
+        self.float_type = 'FLOAT'
+        self.__array = None
         self.xyz_mean = None
         self.xyz_cov = None
         self.ellipsoid = None
@@ -60,21 +121,113 @@ class NLLGrid():
             self.basename = None
 
     def __str__(self):
-        s = 'basename: %s\n' % self.basename
-        s += 'nx: %d ny: %d nz: %d\n' % (self.nx, self.ny, self.nz)
-        s += 'x_orig: %f y_orig: %f z_orig: %f\n'\
-             % (self.x_orig, self.y_orig, self.z_orig)
-        s += 'dx: %f dy: %f dz: %f\n' % (self.dx, self.dy, self.dz)
-        s += 'grid_type: %s\n' % self.type
+        """Info string."""
+        s = 'basename: {}\n'.format(self.basename)
+        s += 'nx: {} ny: {} nz: {}\n'.format(self.nx, self.ny, self.nz)
+        s += 'x_orig: {} y_orig: {} z_orig: {}\n'.format(
+            self.x_orig, self.y_orig, self.z_orig)
+        s += 'dx: {} dy: {} dz: {}\n'.format(self.dx, self.dy, self.dz)
+        s += 'grid_type: {}\n'.format(self.type)
+        s += 'float_type: {}\n'.format(self.float_type)
         if self.station is not None:
-            s += 'station: %s sta_x: %f sta_y: %f sta_z: %f\n'\
-                    % (self.station, self.sta_x, self.sta_y, self.sta_z)
-        s += 'transform: %s' % self.get_transform_line()
+            s += 'station: {} sta_x: {} sta_y: {} sta_z: {}\n'.format(
+                self.station, self.sta_x, self.sta_y, self.sta_z)
+        s += 'transform: {}'.format(self.get_transform_line())
         return s
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(self.__str__())
+
     def __getitem__(self, key):
-        if self.array is not None:
+        """Make the grid object array-like."""
+        if self.type in ['ANGLE', 'ANGLE2D']:
+            return self.dip[key]
+        elif self.array is not None:
             return self.array[key]
+
+    @property
+    def array(self):
+        """Property getter."""
+        return self.__array
+
+    @array.setter
+    def array(self, array_data):
+        array_data = np.asarray(array_data)
+        if array_data.ndim != 3:
+            raise ValueError('Only 3D arrays are supported')
+        self.nx, self.ny, self.nz = array_data.shape
+        self.__array = array_data
+
+    @property
+    def type(self):
+        """Property getter."""
+        return self.__type
+
+    @type.setter
+    def type(self, grid_type):
+        try:
+            grid_type = grid_type.upper()
+        except AttributeError:
+            raise ValueError('Grid type must be a string')
+        if grid_type not in valid_grid_types:
+            msg = 'Invalid grid type: {}\n'.format(grid_type)
+            msg += 'Valid grid types are: {}'.format(valid_grid_types)
+            raise ValueError(msg)
+        self.__type = grid_type
+
+    @property
+    def float_type(self):
+        """Property getter."""
+        return self.__float_type
+
+    @float_type.setter
+    def float_type(self, float_type):
+        try:
+            float_type = float_type.upper()
+        except AttributeError:
+            raise ValueError('Float type must be a string')
+        if float_type not in valid_float_types:
+            msg = 'Invalid float type: {}\n'.format(float_type)
+            msg += 'Valid grid types are: {}'.format(
+                tuple(valid_float_types.keys()))
+            raise ValueError(msg)
+        self.__np_float_type = valid_float_types[float_type]
+        self.__float_type = float_type
+
+    @property
+    def proj_name(self):
+        """Property getter."""
+        return self.__proj_name
+
+    @proj_name.setter
+    def proj_name(self, pname):
+        try:
+            pname = pname.upper()
+        except AttributeError:
+            raise ValueError('Projection name must be a string')
+        if pname not in valid_projections:
+            msg = 'Invalid projection name: {}\n'.format(pname)
+            msg += 'Valid projection names: {}'.format(valid_projections)
+            raise ValueError(msg)
+        self.__proj_name = pname
+
+    @property
+    def proj_ellipsoid(self):
+        """Property getter."""
+        return self.__proj_ellipsoid
+
+    @proj_ellipsoid.setter
+    def proj_ellipsoid(self, ellipsoid):
+        try:
+            # here we just use upper() to check if ellipsoid is a string
+            ellipsoid.upper()
+        except AttributeError:
+            raise ValueError('Ellipsoid must be a string')
+        if ellipsoid not in valid_ellipsoids:
+            msg = 'Invalid ellipsoid: {}\n'.format(ellipsoid)
+            msg += 'Valid ellipsoids: {}'.format(valid_ellipsoids)
+            raise ValueError(msg)
+        self.__proj_ellipsoid = ellipsoid
 
     def remove_extension(self, basename):
         """Remove '.hdr' or '.buf' suffixes, if there."""
@@ -82,6 +235,13 @@ class NLLGrid():
         return bntmp.rsplit('.buf', 1)[0]
 
     def init_array(self):
+        """Init the array to zeros.
+
+        Example of usage:
+        >>> grd = NLLGrid(nx=20, ny=20, nz=30, dx=2., dy=2., dz=2.)
+        >>> grd.init_array()
+        >>> grd.array[2, 4, 10] = 3.
+        """
         self.array = np.zeros((self.nx, self.ny, self.nz), float)
 
     def read_hdr_file(self, basename=None):
@@ -106,12 +266,19 @@ class NLLGrid():
         self.dy = float(vals[7])
         self.dz = float(vals[8])
         self.type = vals[9]
+        try:
+            self.float_type = vals[10]
+        except IndexError:
+            self.float_type = 'FLOAT'
 
         lines.pop(0)
 
         for line in lines:
             vals = line.split()
-            if vals[0] == 'TRANSFORM':
+            if not vals:
+                # skip empty lines
+                continue
+            if vals[0] in ['TRANS', 'TRANSFORM']:
                 if vals[1] == 'NONE':
                     self.proj_name = 'NONE'
                 if vals[1] == 'SIMPLE':
@@ -140,9 +307,29 @@ class NLLGrid():
         filename = self.basename + '.buf'
 
         with open(filename, 'rb') as fp:
-            buf = array(str('f'))
-            buf.fromfile(fp, self.nx * self.ny * self.nz)
-        self.array = np.array(buf).reshape(self.nx, self.ny, self.nz)
+            nitems = self.nx * self.ny * self.nz
+            buf = np.fromfile(fp, dtype=self.__np_float_type, count=nitems)
+            if len(buf) < nitems:
+                raise ValueError(
+                    'Not enough data values in buf file! '
+                    '({} < {})'.format(len(buf), nitems))
+        if self.type in ['ANGLE', 'ANGLE2D']:
+            take_off_angles = (TakeOffAngles * len(buf))()
+            for _i, _val in enumerate(buf):
+                take_off_angles[_i].fval = _val
+            self.azimuth = np.array(
+                [t.ival[1]/10. for t in take_off_angles]
+                ).reshape(self.nx, self.ny, self.nz)
+            self.dip = np.array(
+                [(t.ival[0]//16)/10. for t in take_off_angles]
+                ).reshape(self.nx, self.ny, self.nz)
+            self.quality = np.array(
+                [t.ival[0] % 16 for t in take_off_angles]
+                ).reshape(self.nx, self.ny, self.nz)
+            self.azimuth[self.quality == 0] = np.nan
+            self.dip[self.quality == 0] = np.nan
+        else:
+            self.array = np.array(buf).reshape(self.nx, self.ny, self.nz)
 
     def write_hdr_file(self, basename=None):
         """Write header file of NLL grid format."""
@@ -151,17 +338,18 @@ class NLLGrid():
         filename = self.basename + '.hdr'
 
         lines = []
-        lines.append('%d %d %d  %.6f %.6f %.6f  %.6f %.6f %.6f %s\n' %
-                     (self.nx, self.ny, self.nz,
-                      self.x_orig, self.y_orig, self.z_orig,
-                      self.dx, self.dy, self.dz,
-                      self.type))
+        lines.append('{} {} {}  {:.6f} {:.6f} {:.6f}  '
+                     '{:.6f} {:.6f} {:.6f} {} {}\n'.format(
+                        self.nx, self.ny, self.nz,
+                        self.x_orig, self.y_orig, self.z_orig,
+                        self.dx, self.dy, self.dz,
+                        self.type, self.float_type))
         if self.station is not None:
-            lines.append('%s %.6f %.6f %.6f\n' %
-                         (self.station, self.sta_x, self.sta_y, self.sta_z))
+            lines.append('{} {:.6f} {:.6f} {:.6f}\n'.format(
+                self.station, self.sta_x, self.sta_y, self.sta_z))
         line = self.get_transform_line()
         if line is not None:
-            lines.append('%s\n' % line)
+            lines.append('{}\n'.format(line))
 
         with open(filename, 'w') as fp:
             for line in lines:
@@ -169,46 +357,52 @@ class NLLGrid():
 
     def write_buf_file(self, basename=None):
         """Write buf file as a 3d array."""
+        if self.type in ['ANGLE', 'ANGLE2D']:
+            raise NotImplementedError(
+                'Writing buf file not implemented for ANGLE grid.')
         if self.array is None:
             return
-
         if basename is not None:
             self.basename = basename
         filename = self.basename + '.buf'
-
         with open(filename, 'wb') as fp:
-            self.array.astype(np.float32).tofile(fp)
+            self.array.astype(self.__np_float_type).tofile(fp)
 
     def get_transform_line(self):
+        """Get the transform line in NLL hdr format."""
         if self.proj_name == 'NONE':
             return 'TRANSFORM  NONE'
         if self.proj_name == 'SIMPLE':
             line = 'TRANSFORM  SIMPLE  '
-            line += 'LatOrig %.6f  LongOrig %.6f  RotCW %.6f' %\
-                    (self.orig_lat, self.orig_lon, self.map_rot)
+            line += 'LatOrig {:.6f}  LongOrig {:.6f}  RotCW {:.6f}'.format(
+                self.orig_lat, self.orig_lon, self.map_rot)
             return line
         if self.proj_name == 'LAMBERT':
-            line = 'TRANSFORM  LAMBERT RefEllipsoid %s  ' % self.proj_ellipsoid
-            line += 'LatOrig %.6f  LongOrig %.6f  ' \
-                    % (self.orig_lat, self.orig_lon)
-            line += 'FirstStdParal %.6f  SecondStdParal %.6f  RotCW %.6f' %\
-                    (self.first_std_paral, self.second_std_paral, self.map_rot)
+            line = 'TRANSFORM  LAMBERT RefEllipsoid {}  '.format(
+                self.proj_ellipsoid)
+            line += 'LatOrig {:.6f}  LongOrig {:.6f}  '.format(
+                self.orig_lat, self.orig_lon)
+            line += 'FirstStdParal {:.6f}  SecondStdParal {:.6f}  '.format(
+                self.first_std_paral, self.second_std_paral)
+            line += 'RotCW {:.6f}'.format(self.map_rot)
             return line
 
     def get_xyz(self, i, j, k):
+        """Get cartesian coordinates (x, y, z) for grid indexes (i, j, k)."""
         x = i * self.dx + self.x_orig
         y = j * self.dy + self.y_orig
         z = k * self.dz + self.z_orig
         return x, y, z
 
     def get_ijk(self, x, y, z):
+        """Get grid indexes (i, j, k) for cartesian coordinates (x, y, z)."""
         i = int((x - self.x_orig) / self.dx)
         j = int((y - self.y_orig) / self.dy)
         k = int((z - self.z_orig) / self.dz)
         return i, j, k
 
     def get_ijk_max(self):
-        """Return the indexes (i,j,k) of the grid max point."""
+        """Return the indexes (i, j, k) of the grid max point."""
         if self.array is None:
             return None
         return np.unravel_index(self.array.argmax(), self.array.shape)
@@ -256,7 +450,7 @@ class NLLGrid():
         return (xmean, ymean, zmean)
 
     def get_xyz_cov(self):
-        """Return the grid covariance with respect to the mean point."""
+        """Return the grid covariance respect to the (x,y,z) mean point."""
         if self.array is None:
             return None
         xyz_mean = self.get_xyz_mean()
@@ -266,30 +460,27 @@ class NLLGrid():
         yarray, xarray, zarray = np.meshgrid(yy, xx, zz)
         array_sum = self.array.sum()
         cov = np.zeros((3, 3))
-        cov[0, 0] =\
-            (np.power(xarray, 2) * self.array).sum()/array_sum -\
-            (xyz_mean[0] * xyz_mean[0])
+        cov[0, 0] = (np.power(xarray, 2) * self.array).sum()/array_sum \
+            - (xyz_mean[0] * xyz_mean[0])
         cov[0, 1] = cov[1, 0] =\
-            (xarray * yarray * self.array).sum()/array_sum -\
-            (xyz_mean[0] * xyz_mean[1])
-        cov[0, 2] = cov[2, 0] =\
-            (xarray * zarray * self.array).sum()/array_sum -\
-            (xyz_mean[0] * xyz_mean[2])
-        cov[1, 1] =\
-            (np.power(yarray, 2) * self.array).sum()/array_sum -\
-            (xyz_mean[1] * xyz_mean[1])
-        cov[1, 2] = cov[2, 1] =\
-            (yarray * zarray * self.array).sum()/array_sum -\
-            (xyz_mean[1] * xyz_mean[2])
-        cov[2, 2] =\
-            (np.power(zarray, 2) * self.array).sum()/array_sum -\
-            (xyz_mean[2] * xyz_mean[2])
+            (xarray * yarray * self.array).sum()/array_sum \
+            - (xyz_mean[0] * xyz_mean[1])
+        cov[0, 2] = cov[2, 0] = \
+            (xarray * zarray * self.array).sum()/array_sum \
+            - (xyz_mean[0] * xyz_mean[2])
+        cov[1, 1] = (np.power(yarray, 2) * self.array).sum()/array_sum \
+            - (xyz_mean[1] * xyz_mean[1])
+        cov[1, 2] = cov[2, 1] = \
+            (yarray * zarray * self.array).sum()/array_sum \
+            - (xyz_mean[1] * xyz_mean[2])
+        cov[2, 2] = (np.power(zarray, 2) * self.array).sum()/array_sum \
+            - (xyz_mean[2] * xyz_mean[2])
         self.xyz_cov = cov
         return cov
 
     def get_xyz_ellipsoid(self):
-        """Return the 68% confidence ellipsoid respect to the mean point."""
-        from .ellipsoid import Ellipsoid3D
+        """Return the 68% confidence ellipsoid."""
+        from ellipsoid import Ellipsoid3D
         # The following code is a python translation of the
         # CalcErrorEllipsoid() c-function from the NonLinLoc package,
         # written by Anthony Lomax
@@ -316,13 +507,22 @@ class NLLGrid():
         self.ellipsoid = ell
         return ell
 
-    def get_value(self, x, y, z):
-        if self.array is None:
-            return
+    def get_value(self, x, y, z, array=None):
+        """Get the array value at specified cartesian coordinates (x, y, z)."""
+        if array is None:
+            if self.array is None:
+                return
+            else:
+                array = self.array
+        min_x, max_x, min_y, max_y, min_z, max_z = self.get_extent()
+        if not (min_x <= x <= max_x and min_y <= y <= max_y and
+                min_z <= z <= max_z):
+            raise ValueError('point {} outside the grid.'.format((x, y, z)))
         i, j, k = self.get_ijk(x, y, z)
-        return self.array[i, j, k]
+        return array[i, j, k]
 
     def get_extent(self):
+        """Get the grid extent in cartesian units (generally km)."""
         extent = (self.x_orig - self.dx / 2,
                   self.x_orig + self.nx * self.dx + self.dx / 2,
                   self.y_orig - self.dy / 2,
@@ -333,25 +533,37 @@ class NLLGrid():
         return extent
 
     def get_xy_extent(self):
+        """Get the grid xy extent in cartesian units (generally km)."""
         return self.get_extent()[0:4]
 
     def get_xz_extent(self):
+        """Get the grid xz extent in cartesian units (generally km)."""
         return self.get_extent()[0:2] + self.get_extent()[4:]
 
     def get_zx_extent(self):
+        """Get the grid zx extent in cartesian units (generally km)."""
         return self.get_extent()[4:] + self.get_extent()[0:2]
 
     def get_yz_extent(self):
+        """Get the grid yz extent in cartesian units (generally km)."""
         return self.get_extent()[2:]
 
     def get_zy_extent(self):
+        """Get the grid zy extent in cartesian units (generally km)."""
         return self.get_extent()[4:] + self.get_extent()[2:4]
 
     def max(self):
+        """Get the grid max value."""
+        if self.type in ['ANGLE', 'ANGLE2D']:
+            return np.nanmax(self.dip)
         if self.array is not None:
-            return self.array.max()
+            return np.nanmax(self.array)
 
     def resample(self, dx, dy, dz):
+        """Resample grid to (dx, dy, dz)."""
+        if self.type in ['ANGLE', 'ANGLE2D']:
+            raise NotImplementedError(
+                'Resample not implemented for ANGLE grid.')
         zoom_x = self.dx / dx
         zoom_y = self.dy / dy
         zoom_z = self.dz / dz
@@ -364,6 +576,10 @@ class NLLGrid():
         self.dz = dz
 
     def get_plot_axes(self, figure=None, ax_xy=None):
+        """Get the axes for the three projections, plus the colorbar axis.
+
+        Requires Matplotlib.
+        """
         import matplotlib.pyplot as plt
         from mpl_toolkits.axes_grid1 import make_axes_locatable
 
@@ -392,8 +608,8 @@ class NLLGrid():
         plt.setp(ax_xy.get_yticklabels(), rotation=90, fontsize=12)
 
         # ax_yz
-        ax_yz = divider.append_axes('right', size=yz_size, pad=0.05,
-                                    sharey=ax_xy)
+        ax_yz = divider.append_axes(
+            'right', size=yz_size, pad=0.05, sharey=ax_xy)
         plt.setp(ax_yz.get_yticklabels(), visible=False)
         ax_yz.set_xlim(zmin, zmax)
         ax_yz.set_ylim(ymin, ymax)
@@ -401,8 +617,8 @@ class NLLGrid():
         plt.setp(ax_yz.get_yticklabels(), rotation=90, fontsize=12)
 
         # ax_xz
-        ax_xz = divider.append_axes('bottom', size=xz_size, pad=0.05,
-                                    sharex=ax_xy)
+        ax_xz = divider.append_axes(
+            'bottom', size=xz_size, pad=0.05, sharex=ax_xy)
         ax_xz.set_xlim(xmin, xmax)
         ax_xz.set_ylim(zmax, zmin)
 
@@ -412,37 +628,48 @@ class NLLGrid():
         return ax_xy, ax_xz, ax_yz, ax_cb
 
     def plot(self, slice_index=None, handle=False, figure=None, ax_xy=None,
-             vmin=None, vmax=None, cmap=None):
+             vmin=None, vmax=None, cmap=None, array=None):
+        """Plot the grid using three orthogonal projections.
+
+        Requires Matplotlib.
+        """
         import matplotlib.pyplot as plt
         from matplotlib import ticker
+
+        if array is None:
+            if self.array is None:
+                return
+            else:
+                array = self.array
 
         ax_xy, ax_xz, ax_yz, ax_cb = self.get_plot_axes(figure, ax_xy)
         if figure is None:
             figure = ax_xy.get_figure()
 
         if slice_index is None:
-            slice_index = tuple(int(v) for v in
-                                (self.nx/2, self.ny/2, self.nz/2))
+            slice_index = list(map(int, (self.nx/2, self.ny/2, self.nz/2)))
         if slice_index == 'max':
             slice_index = self.get_ijk_max()
         if slice_index == 'min':
             slice_index = self.get_ijk_min()
 
-        hnd = ax_xy.imshow(np.transpose(self.array[:, :, slice_index[2]]),
+        if vmin is None:
+            vmin = np.nanmin(array)
+        if vmax is None:
+            vmax = np.nanmax(array)
+
+        hnd = ax_xy.imshow(np.transpose(array[:, :, slice_index[2]]),
                            vmin=vmin, vmax=vmax, cmap=cmap,
                            origin='lower', extent=self.get_xy_extent(),
                            zorder=-10)
-        ax_xy.set_adjustable('box-forced')
-        ax_xz.imshow(np.transpose(self.array[:, slice_index[1], :]),
+        ax_xz.imshow(np.transpose(array[:, slice_index[1], :]),
                      vmin=vmin, vmax=vmax, cmap=cmap,
                      origin='lower', extent=self.get_xz_extent(),
                      aspect='auto', zorder=-10)
-        ax_xz.set_adjustable('box-forced')
-        ax_yz.imshow(self.array[slice_index[0], :, :],
+        ax_yz.imshow(array[slice_index[0], :, :],
                      vmin=vmin, vmax=vmax, cmap=cmap,
                      origin='lower', extent=self.get_zy_extent(),
                      aspect='auto', zorder=-10)
-        ax_yz.set_adjustable('box-forced')
 
         x_slice, y_slice, z_slice = self.get_xyz(*slice_index)
         ax_xy.axhline(y_slice, color='w', linestyle='dashed', zorder=-1)
@@ -450,9 +677,9 @@ class NLLGrid():
         ax_xz.axhline(z_slice, color='w', linestyle='dashed', zorder=-1)
         ax_yz.axvline(z_slice, color='w', linestyle='dashed', zorder=-1)
 
-        fmt = '%.1e' if self.max() <= 0.01 else '%.2f'
-        cb = figure.colorbar(hnd, cax=ax_cb, orientation='horizontal',
-                             format=fmt)
+        fmt = '%.1e' if np.nanmax(array) <= 0.01 else '%.2f'
+        cb = figure.colorbar(
+            hnd, cax=ax_cb, orientation='horizontal', format=fmt)
         cb.locator = ticker.LinearLocator(numticks=3)
         cb.update_ticks()
 
@@ -462,13 +689,15 @@ class NLLGrid():
             plt.show()
 
     def plot_3D_point(self, axes, point, color='r'):
+        """Plot a point (i, j, k) on the grid."""
         ax_xy, ax_xz, ax_yz = axes
         ax_xy.scatter(point[0], point[1], color=color)
         ax_xz.scatter(point[0], point[2], color=color)
         ax_yz.scatter(point[2], point[1], color=color)
 
     def plot_ellipsoid(self, axes, ellipsoid=None, mean_xyz=None):
-        from .ellipsoid import Vect3D, ellipsiod2Axes, toEllipsoid3D
+        """Plot an ellipsoid on the grid."""
+        from ellipsoid import Vect3D, ellipsiod2Axes, toEllipsoid3D
         ax_xy, ax_xz, ax_yz = axes
 
         if ellipsoid is None:
@@ -505,20 +734,77 @@ class NLLGrid():
         ax_yz.plot(ell13[:, 1], ell13[:, 0])
         ax_yz.plot(ell23[:, 1], ell23[:, 0])
 
+    def project(self, lon, lat):
+        """Project lon, lat into grid coordinates."""
+        if self.proj_name == 'LAMBERT':
+            ellipsoids = {
+                'WGS-84': 'WGS84',
+                'GRS-80': 'GRS80',
+                'WGS-72': 'WGS72',
+                'Australian': 'aust_SA',
+                'Krasovsky': 'krass',
+                'International': 'new_intl',
+                'Hayford-1909': 'intl',
+                'Clarke-1880': 'clrk80',
+                'Clarke-1866': 'clrk66',
+                'Airy': 'airy',
+                'Bessel': 'bessel',
+                # 'Hayford-1830':
+                'Sphere': 'sphere'
+                }
+            try:
+                ellps = ellipsoids[self.proj_ellipsoid]
+            except KeyError:
+                raise ValueError(
+                    'Ellipsoid not supported: {}'.format(self.proj_ellipsoid))
+            p = Proj(proj='lcc', lat_0=self.orig_lat, lon_0=self.orig_lon,
+                     lat_1=self.first_std_paral, lat_2=self.second_std_paral,
+                     ellps=ellps)
+        elif self.proj_name == 'SIMPLE':
+            p = Proj(proj='eqc', lat_0=self.orig_lat, lon_0=self.orig_lon)
+        else:
+            raise ValueError('Projection not supported: {}'.format(
+                self.proj_name))
+        x, y = p(lon, lat)
+        x = np.array(x)
+        y = np.array(y)
+        x[np.isnan(lon)] = np.nan
+        y[np.isnan(lat)] = np.nan
+        x /= 1000.
+        y /= 1000.
+        # inverse rotation
+        theta = np.radians(self.map_rot)
+        x1 = x*np.cos(theta) + y*np.sin(theta)
+        y1 = -x*np.sin(theta) + y*np.cos(theta)
+        x = x1
+        y = y1
+        # Try to return the same type of lon, lat
+        if not isinstance(lon, np.ndarray):
+            if isinstance(lon, Iterable):
+                x = type(lon)(x)
+            else:
+                x = float(x)
+        if not isinstance(lat, np.ndarray):
+            if isinstance(lat, Iterable):
+                y = type(lat)(y)
+            else:
+                y = float(y)
+        return x, y
+
     def copy(self):
+        """Get a deep copy of the grid object."""
         return deepcopy(self)
 
 
 def main():
-    """
-    Test code.
+    """Test code.
 
-    Generates a gaussian grid and computes
-    the 3D ellipsoid around the grid mean
+    It generates a gaussian grid and computes the 3D ellipsoid
+    around the grid mean.
     """
     import matplotlib.pyplot as plt
 
-    #http://stackoverflow.com/q/17190649
+    # http://stackoverflow.com/q/17190649
     def gauss3D(shape=(3, 3, 3), sigmax=0.5, sigmay=0.5, sigmaz=0.5, theta=0):
         m, n, k = [(ss-1.)/2. for ss in shape]
         y, x, z = np.ogrid[-m:m+1, -n:n+1, -k:k+1]
@@ -545,7 +831,6 @@ def main():
                   dx=1, dy=1, dz=1,
                   x_orig=x_orig, y_orig=y_orig)
     print(grd)
-    grd.init_array()
     grd.array = gauss3D((nx, ny, nz), 20, 10, 2, 30)
 
     # Compute statistics

--- a/backtrackbb/nllgrid/__init__.py
+++ b/backtrackbb/nllgrid/__init__.py
@@ -1,0 +1,4 @@
+from .NLLGrid import NLLGrid
+from .version import get_git_version
+
+__version__ = get_git_version()

--- a/backtrackbb/nllgrid/ellipsoid.py
+++ b/backtrackbb/nllgrid/ellipsoid.py
@@ -1,5 +1,15 @@
-# Python porting of c-code from matrix_statistics.c,
-# part of the NonLinLoc package, written by Anthony Lomax
+# -*- coding: utf8 -*-
+"""
+Python porting of c-code from matrix_statistics.c.
+
+Part of the NonLinLoc package, written by Anthony Lomax.
+
+:copyright:
+    2013-2018 Claudio Satriano <satriano@ipgp.fr>
+:license:
+    CeCILL Free Software License Agreement, Version 2.1
+    (http://www.cecill.info/index.en.html)
+"""
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
@@ -7,18 +17,21 @@ from math import pi, cos, sin
 
 
 class Ellipsoid3D():
-    #semi-minor axis km
+    """A 3D ellipsoid."""
+
+    # semi-minor axis km
     az1 = None
     dip1 = None
     len1 = None
-    #semi-intermediate axis km
+    # semi-intermediate axis km
     az2 = None
     dip2 = None
     len2 = None
-    #semi-major axis km
+    # semi-major axis km
     len3 = None
 
     def __str__(self):
+        """String representation."""
         s = 'az1: %f\n' % self.az1
         s += 'dip1: %f\n' % self.dip1
         s += 'len1: %f\n' % self.len1
@@ -30,16 +43,20 @@ class Ellipsoid3D():
 
 
 class Vect3D():
+    """A 3D vector."""
+
     x = None
     y = None
     z = None
 
     def __str__(self):
+        """String representation."""
         s = 'x: %f y: %f z: %f' % (self.x, self.y, self.z)
         return s
 
 
 def cross_product_3d(vect_a, vect_b):
+    """Cross product between two 3D vectors."""
     product = Vect3D()
     product.x = vect_a.y * vect_b.z - vect_a.z * vect_b.y
     product.y = vect_a.z * vect_b.x - vect_a.x * vect_b.z
@@ -48,6 +65,7 @@ def cross_product_3d(vect_a, vect_b):
 
 
 def ellipsiod2Axes(pellipsoid):
+    """Get the three axes of an ellipsoid."""
     DE2RA = pi/180
 
     # strike angles positive CCW from East = 0
@@ -57,7 +75,7 @@ def ellipsiod2Axes(pellipsoid):
     dip1 = -pellipsoid.dip1
     dip2 = -pellipsoid.dip2
 
-    #get 3D vector axes
+    # get 3D vector axes
     cosd1 = cos(DE2RA * pellipsoid.dip1)
     paxis1 = Vect3D()
     paxis1.x = cos(DE2RA * az1) * cosd1
@@ -86,6 +104,7 @@ def ellipsiod2Axes(pellipsoid):
 
 
 def toEllipsoid3D(ax1, ax2, center, npts):
+    """Get the coordinates of a 3D ellipsoid defined by 2 axes and a center."""
     d_angle = 2.0 * pi / (npts - 1)
     angle = 0.0
 
@@ -104,6 +123,7 @@ def toEllipsoid3D(ax1, ax2, center, npts):
 
 
 def main():
+    """Test code."""
     import numpy as np
     import matplotlib.pyplot as plt
 

--- a/backtrackbb/nllgrid/version.py
+++ b/backtrackbb/nllgrid/version.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+# Author: Douglas Creager <dcreager@dcreager.net>
+# This file is placed into the public domain.
+#
+# Modified from the ObsPy project
+
+# Calculates the current version number.  If possible, this is the
+# output of “git describe”, modified to conform to the versioning
+# scheme that setuptools uses.  If “git describe” returns an error
+# (most likely because we're in an unpacked copy of a release tarball,
+# rather than in a git working copy), then we fall back on reading the
+# contents of the RELEASE-VERSION file.
+#
+# To use this script, simply import it your setup.py file, and use the
+# results of get_git_version() as your package version:
+#
+# from version import *
+#
+# setup(
+#     version=get_git_version(),
+#     .
+#     .
+#     .
+# )
+#
+# This will automatically update the RELEASE-VERSION file, if
+# necessary.  Note that the RELEASE-VERSION file should *not* be
+# checked into git; please add it to your top-level .gitignore file.
+#
+# You'll probably want to distribute the RELEASE-VERSION file in your
+# sdist tarballs; to do this, just create a MANIFEST.in file that
+# contains the following line:
+#
+#   include RELEASE-VERSION
+# NO IMPORTS FROM NLLGRID OR FUTURE IN THIS FILE! (file gets used at
+# installation time)
+import io
+import os
+import inspect
+from subprocess import Popen, PIPE
+
+__all__ = ("get_git_version")
+
+
+script_dir = os.path.abspath(os.path.dirname(inspect.getfile(
+                                             inspect.currentframe())))
+NLLGRID_ROOT = os.path.abspath(os.path.join(script_dir, os.pardir))
+VERSION_FILE = os.path.join(script_dir, "RELEASE-VERSION")
+
+
+def call_git_describe(abbrev=4):
+    try:
+        p = Popen(['git', 'rev-parse', '--show-toplevel'],
+                  cwd=NLLGRID_ROOT, stdout=PIPE, stderr=PIPE)
+        p.stderr.close()
+        path = p.stdout.readline().decode().strip()
+        p.stdout.close()
+    except Exception:
+        return None
+    if os.path.normpath(path) != NLLGRID_ROOT:
+        return None
+    try:
+        p = Popen(['git', 'describe', '--dirty', '--abbrev=%d' % abbrev,
+                   '--always', '--tags'],
+                  cwd=NLLGRID_ROOT, stdout=PIPE, stderr=PIPE)
+
+        p.stderr.close()
+        line = p.stdout.readline().decode()
+        p.stdout.close()
+
+        if "-" not in line and "." not in line:
+            line = "0.0.0-g%s" % line
+        return line.strip()
+    except Exception:
+        return None
+
+
+def read_release_version():
+    try:
+        with io.open(VERSION_FILE, "rt") as fh:
+            version = fh.readline()
+        return version.strip()
+    except Exception:
+        return None
+
+
+def write_release_version(version):
+    with io.open(VERSION_FILE, "wb") as fh:
+        fh.write(("%s\n" % version).encode('ascii', 'strict'))
+
+
+def get_git_version(abbrev=4):
+    # Read in the version that's currently in RELEASE-VERSION.
+    release_version = read_release_version()
+
+    # First try to get the current version using “git describe”.
+    version = call_git_describe(abbrev)
+
+    # If that doesn't work, fall back on the value that's in
+    # RELEASE-VERSION.
+    if version is None:
+        version = release_version
+
+    # If we still don't have anything, that's an error.
+    if version is None:
+        return '0.0.0-tar/zipball'
+
+    # If the current version is different from what's in the
+    # RELEASE-VERSION file, update the file to be current.
+    if version != release_version:
+        write_release_version(version)
+
+    # Finally, return the current version.
+    return version
+
+
+if __name__ == "__main__":
+    print(get_git_version())

--- a/backtrackbb/read_grids.py
+++ b/backtrackbb/read_grids.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 import os
 from glob import glob
 from collections import defaultdict
-from .NLLGrid import NLLGrid
+from .nllgrid import NLLGrid
 
 
 def read_grids(config):

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,12 @@ ext_modules.append(Extension(
 
 setup(
     name='backtrackbb',
-    packages=['backtrackbb', 'backtrackbb.scripts', 'backtrackbb.configobj'],
+    packages=[
+        'backtrackbb',
+        'backtrackbb.scripts',
+        'backtrackbb.configobj',
+        'backtrackbb.nllgrid'
+        ],
     include_package_data=True,
     entry_points={
         'console_scripts': [
@@ -75,5 +80,5 @@ setup(
             'Programming Language :: Python :: 3.5',
             'Topic :: Scientific/Engineering',
             'Topic :: Scientific/Engineering :: Physics'],
-    install_requires=['obspy>=1.0.0', 'scipy>=0.17']
+    install_requires=['obspy>=1.0.0', 'scipy>=0.17', 'pyproj']
     )


### PR DESCRIPTION
Among the other improvements, this fixes a bug with .hdr file having a `TRANS` line instead of `TRANSFORM`.
It also allows to use double-precision grids.

Also, moves NLLGrid to `nllgrid` subdir.

Finally, adds as install requirement `pyproj`.

Please test!!!