### PR TITLE
Fix module importing for Python2

### DIFF
--- a/backtrackbb/map_project.py
+++ b/backtrackbb/map_project.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 import ctypes
 try:
     from .lib_names import get_lib_path
-except ImportError:
+except (ImportError, ValueError):
     from lib_names import get_lib_path
 
 

--- a/backtrackbb/mod_filter_picker.py
+++ b/backtrackbb/mod_filter_picker.py
@@ -11,7 +11,7 @@ try:
     from .rec_hos import recursive_hos
     from .rec_gauss_filter import recursive_gauss_filter
     from .rosenberger import rosenberger
-except ImportError:
+except (ImportError, ValueError):
     from rec_filter import recursive_filter
     from rec_rms import recursive_rms
     from rec_hos import recursive_hos

--- a/backtrackbb/rec_cc.py
+++ b/backtrackbb/rec_cc.py
@@ -7,7 +7,7 @@ from ctypes import CDLL, c_int, c_double, c_void_p
 from numpy.ctypeslib import ndpointer
 try:
     from .lib_names import get_lib_path
-except ImportError:
+except (ImportError, ValueError):
     from lib_names import get_lib_path
 
 

--- a/backtrackbb/rec_filter.py
+++ b/backtrackbb/rec_filter.py
@@ -7,7 +7,7 @@ from ctypes import CDLL, c_int, c_float, c_double, c_void_p, POINTER, byref
 from numpy.ctypeslib import ndpointer
 try:
     from .lib_names import get_lib_path
-except ImportError:
+except (ImportError, ValueError):
     from lib_names import get_lib_path
 
 

--- a/backtrackbb/rec_gauss_filter.py
+++ b/backtrackbb/rec_gauss_filter.py
@@ -7,7 +7,7 @@ from ctypes import CDLL, c_int, c_double, c_void_p
 from numpy.ctypeslib import ndpointer
 try:
     from .lib_names import get_lib_path
-except ImportError:
+except (ImportError, ValueError):
     from lib_names import get_lib_path
 
 

--- a/backtrackbb/rec_hos.py
+++ b/backtrackbb/rec_hos.py
@@ -15,7 +15,7 @@ from ctypes import CDLL, c_int, c_float, c_double, c_void_p, POINTER, byref
 from numpy.ctypeslib import ndpointer
 try:
     from .lib_names import get_lib_path
-except ImportError:
+except (ImportError, ValueError):
     from lib_names import get_lib_path
 
 

--- a/backtrackbb/rec_rms.py
+++ b/backtrackbb/rec_rms.py
@@ -7,7 +7,7 @@ from ctypes import CDLL, c_int, c_float, c_double, c_void_p, POINTER, byref
 from numpy.ctypeslib import ndpointer
 try:
     from .lib_names import get_lib_path
-except ImportError:
+except (ImportError, ValueError):
     from lib_names import get_lib_path
 
 

--- a/backtrackbb/rosenberger.py
+++ b/backtrackbb/rosenberger.py
@@ -20,7 +20,7 @@ from numpy.ctypeslib import ndpointer
 from future.utils import PY2
 try:
     from .lib_names import get_lib_path
-except ImportError:
+except (ImportError, ValueError):
     from lib_names import get_lib_path
 
 


### PR DESCRIPTION
This fixed an error with Python2, where an unsuccessful relative import throws a `ValueError` instead of an `ImportError`